### PR TITLE
Various fixes and adjustments related to the calibration of the X150

### DIFF
--- a/config/delivery.yaml
+++ b/config/delivery.yaml
@@ -1,8 +1,11 @@
 delivery_node:
   ros__parameters:
     name: "AcommUsbl"
-    port: "/tmp/usbl0"
+    port: "/dev/ttyUSB0"
     data_rate: 115200
     x150_id: 15
+    yaw_offset: 0
+    pitch_offset: 0
+    roll_offset: 180
     x110_id: 1
     ping_period_s: 1

--- a/delivery/script_utils.py
+++ b/delivery/script_utils.py
@@ -37,7 +37,11 @@ def usbl_info(usbl) -> SysInfoResp:
     raise Exception("Failed to get SysInfo")
 
 
-def usbl_setup(usbl, beacon_id: int = 15, roll_offset: int = 0):
+def usbl_setup(usbl,
+               beacon_id: int = 15,
+               yaw_offset: int = 0,
+               pitch_offset: int = 0,
+               roll_offset: int = 0):
     """
     Setup the device for use, such as the ID number, the status messages,
     and the transceiver flags.
@@ -75,8 +79,8 @@ def usbl_setup(usbl, beacon_id: int = 15, roll_offset: int = 0):
     settings_set_cmd.set_salinity(SALINITY_SEAWATER)
     settings_set_cmd.set_ahrs_flags()
     settings_set_cmd.set_env_flags()
-    settings_set_cmd.set_ahrs_offsets(yaw_deg=0,
-                                      pitch_deg=0,
+    settings_set_cmd.set_ahrs_offsets(yaw_deg=yaw_offset,
+                                      pitch_deg=pitch_offset,
                                       roll_deg=roll_offset)
     settings_set_cmd.set_beacon_id(beacon_id)
 

--- a/delivery/usbl_messages.py
+++ b/delivery/usbl_messages.py
@@ -57,11 +57,6 @@ SEA_RESPONSE_DELAY = 10
 #
 MAX_MSG_LENGTH = 31
 
-#
-# To adjust X150 yaw values to ROS yaw values standard, add YAW_OFFSET.
-#
-YAW_OFFSET = 90.0
-
 RANGE_VALID    = 0b00000001  # noqa: E221
 USBL_VALID     = 0b00000010  # noqa: E221
 POSITION_VALID = 0b00000100
@@ -1213,17 +1208,20 @@ class XcvrFixResp(USBLMsg):
         #
         # With the way the X150 is mounted on the ROV, with the transducer
         # pointed down, the connector up, and the Front Reference Marking
-        # facing forward, X is forward, Y is left, and Z is up. This agrees
-        # with
+        # facing forward, X is forward, Y is left, and Z is up, according to:
         # https://www.blueprintsubsea.com/downloads/seatrac/UM-140-D00221-07.pdf
         #
-        # However, in reality, the rotations (roll, pitch, and yaw) do NOT
-        # match the seatrac document. X150 positive pitch is bow up and level
-        # is 0.  Positive roll is starboard down, but level is 180. Positive
-        # yaw is bow left but magnetic north is 0.
+        # TODO: Determine how to offset roll, pitch, and yaw
+        #
+        # However, after setting roll_offset to 180, only the roll values are
+        # correct (port side up is positive). Positive pitch values should
+        # indicate bow down but instead indicate bow up. Yaw values are
+        # inconsistent.
+        # Also, yaw values are NOT compass headings but instead are described
+        # as being relative to magnetic North.
         #
 
-        self.attitude_yaw = ((attributes[4] / 10.0) + YAW_OFFSET) % 360.0
+        self.attitude_yaw = attributes[4] / 10.0
         self.attitude_pitch = attributes[5] / 10.0
         self.attitude_roll = attributes[6] / 10.0
         self.depth_local = attributes[7] / 10.0

--- a/scripts/delivery_node.py
+++ b/scripts/delivery_node.py
@@ -32,6 +32,9 @@ class AcommUsblNode(Node):
                 ('data_rate', Parameter.Type.INTEGER),
                 ('name', Parameter.Type.STRING),
                 ('x150_id', Parameter.Type.INTEGER),
+                ('yaw_offset', Parameter.Type.INTEGER),
+                ('pitch_offset', Parameter.Type.INTEGER),
+                ('roll_offset', Parameter.Type.INTEGER),
                 ('x110_id', Parameter.Type.INTEGER),
                 ('ping_period_s', Parameter.Type.INTEGER)
             ])
@@ -40,6 +43,9 @@ class AcommUsblNode(Node):
                                           'data_rate',
                                           'name',
                                           'x150_id',
+                                          'yaw_offset',
+                                          'pitch_offset',
+                                          'roll_offset',
                                           'x110_id',
                                           'ping_period_s'])
         self._parameters = dict()
@@ -47,8 +53,11 @@ class AcommUsblNode(Node):
         self._parameters['data_rate'] = parameters[1].value
         self._parameters['name'] = parameters[2].value
         self._parameters['x150_id'] = parameters[3].value
-        self._parameters['x110_id'] = parameters[4].value
-        self._parameters['ping_period_s'] = parameters[5].value
+        self._parameters['yaw_offset'] = parameters[4].value
+        self._parameters['pitch_offset'] = parameters[5].value
+        self._parameters['roll_offset'] = parameters[6].value
+        self._parameters['x110_id'] = parameters[7].value
+        self._parameters['ping_period_s'] = parameters[8].value
 
         self._usbl = None
 
@@ -92,7 +101,7 @@ class AcommUsblNode(Node):
         x150_status.pressure_mb = status_resp.pressure_mb
         x150_status.depth_m = status_resp.depth_m
         x150_status.sound_mps = status_resp.sound_mps
-        x150_status.compass_mag = status_resp.yaw_deg
+        x150_status.yaw_deg = status_resp.yaw_deg
         x150_status.pitch_deg = status_resp.pitch_deg
         x150_status.roll_deg = status_resp.roll_deg
 
@@ -165,8 +174,16 @@ class AcommUsblNode(Node):
 
         self.get_logger().info("setup_device waiting for X150 to respond")
         usbl_info(self._usbl)
-        usbl_setup(self._usbl, beacon_id=self._parameters['x150_id'])
-        self.get_logger().info("setup_device X150 configured")
+        usbl_setup(self._usbl,
+                   beacon_id=self._parameters['x150_id'],
+                   yaw_offset=self._parameters['yaw_offset'],
+                   pitch_offset=self._parameters['pitch_offset'],
+                   roll_offset=self._parameters['roll_offset'])
+        self.get_logger().info("setup_device X150 configured, offsets: "
+                               f" roll  {self._parameters['roll_offset']}"
+                               f" pitch {self._parameters['pitch_offset']}"
+                               f" yaw   {self._parameters['yaw_offset']}"
+                               )
 
         self._callbacks = CIDCallbacks()
         self._callback_funcs = CallbackFuncs(

--- a/scripts/test_usbl.py
+++ b/scripts/test_usbl.py
@@ -18,11 +18,6 @@ BEACON_ID = {
     X_ONE_TEN_SERIAL: 1
 }
 
-ROLL_OFFSET = {
-    X_ONE_FIFTY_SERIAL: 180,
-    X_ONE_TEN_SERIAL: 0
-}
-
 usbl = USBL('Unknown', '/dev/ttyUSB0', 115200)
 
 try:
@@ -31,14 +26,12 @@ try:
 
     serial_number = device_info.hardware['serial_number']
     beacon_id = BEACON_ID[serial_number]
-    roll_offset = ROLL_OFFSET[serial_number]
-    print(f"Beacon ID: {beacon_id}, Roll offset: {roll_offset}")
 
 except Exception as e:
     print(f"usbl_info failed: {e}")
 
 try:
-    usbl_setup(usbl=usbl, beacon_id=beacon_id, roll_offset=roll_offset)
+    usbl_setup(usbl=usbl, beacon_id=beacon_id)
 
 except Exception as e:
     print(f"usbl_setup failed: {e}")


### PR DESCRIPTION
The changes are related to Attitude data in the StatusResp message from the X150.

delivery.yaml: Changed the default port to /dev/ttyUSB0. Added
               parameters for roll, pitch, and yaw offsets.

script_utils.py: Implemented all three offsets in usbl_setup().

usbl_messages.py: Removed the YAW_OFFSET constant and tried to
                  clarify the comment in XcvrFixResp related to
                  attitude values.

delivery_node.py: Added use of all three offset parameters and
                  replaced the compass_mag attribute in X150Status
                  with yaw_deg.

test_usbl.py: Removed the ROLL_OFFSET constant. Use the default
              offsets with usbl_setup().

Tested with the delivery_node.py and rqt while manipulating the X150. The roll and pitch values are reasonable. Positive pitch indicates bow up, which is the opposite of the ROS standard. Positive roll is port side up and complies with the ROS standard. Yaw values are not consistent. More testing is required, far away from iron and magentic fields.