### PR TITLE
Improvement of comments and doc strings related to positions

### DIFF
--- a/delivery/callback_funcs.py
+++ b/delivery/callback_funcs.py
@@ -101,10 +101,11 @@ class CallbackFuncs(object):
     def ping_error_cb(self, datagram: USBLDatagram):
         ping_error = PingErrorResp(datagram, self._beacon_id)
         try:
-            error = CST_E(ping_error.status)
+            CST_E(ping_error.status)
+            # TODO: Do something useful with the status
 
         except ValueError:
-            error = f"{ping_error.status}"
+            pass
 
         self._ping_error_diag()
 

--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>delivery</name>
-  <version>0.0.2</version>
+  <version>0.0.3</version>
   <description>ROS2 package to deliver a payload.</description>
   <maintainer email="bill@manialabs.us">Bill Mania</maintainer>
   <license>Proprietary</license>

--- a/scripts/delivery_node.py
+++ b/scripts/delivery_node.py
@@ -108,16 +108,16 @@ class AcommUsblNode(Node):
         self._x150_status_pub.publish(x150_status)
 
     def _range_bearing_cb(self,
-                          range_m: float,
-                          azimuth_deg: float,
-                          elevation_deg: float,
-                          mag_heading_deg: float = None,
-                          pitch_deg: float = None,
-                          roll_deg: float = None,
-                          depth_m: float = None,
-                          remote_east_m: float = None,
-                          remote_north_m: float = None,
-                          remote_depth_m: float = None
+                          x110_range_m: float,
+                          x110_azimuth_deg: float,
+                          x110_elevation_deg: float,
+                          x150_yaw_deg: float = None,
+                          x150_pitch_deg: float = None,
+                          x150_roll_deg: float = None,
+                          x150_depth_m: float = None,
+                          x110_east_m: float = None,
+                          x110_north_m: float = None,
+                          x110_depth_m: float = None
                           ):
         """
         Called when an XcvrFix datagram is received. If the X110 doesn't
@@ -128,30 +128,26 @@ class AcommUsblNode(Node):
         range_bearing.header.stamp = self.get_clock().now().to_msg()
         range_bearing.orientation_present = False
 
-        if (mag_heading_deg is not None
-           and pitch_deg is not None
-           and roll_deg is not None
-           and depth_m is not None):
+        if (x150_yaw_deg is not None
+           and x150_pitch_deg is not None
+           and x150_roll_deg is not None
+           and x150_depth_m is not None):
             range_bearing.orientation_present = True
-            range_bearing.mag_heading_deg = mag_heading_deg
-            range_bearing.pitch_deg = pitch_deg
-            range_bearing.roll_deg = roll_deg
-            range_bearing.depth_m = depth_m
+            range_bearing.yaw_deg = x150_yaw_deg
+            range_bearing.pitch_deg = x150_pitch_deg
+            range_bearing.roll_deg = x150_roll_deg
+            range_bearing.depth_m = x150_depth_m
+        else:
+            range_bearing.orientation_present = False
 
-        if range_m is not None:
+        if x110_range_m is not None:
             range_bearing.range_present = True
-            #
-            # There is intentional redundancy here.
-            # The X150 uses the range, azimuth, and elevation
-            # to calculate the remote east and north. remote_depth_m
-            # is provided directly by the X110.
-            #
-            range_bearing.range_m = range_m
-            range_bearing.azimuth_deg = azimuth_deg
-            range_bearing.elevation_deg = elevation_deg
-            range_bearing.remote_east_m = remote_east_m
-            range_bearing.remote_north_m = remote_north_m
-            range_bearing.remote_depth_m = remote_depth_m
+            range_bearing.range_m = x110_range_m
+            range_bearing.azimuth_deg = x110_azimuth_deg
+            range_bearing.elevation_deg = x110_elevation_deg
+            range_bearing.remote_east_m = x110_east_m
+            range_bearing.remote_north_m = x110_north_m
+            range_bearing.remote_depth_m = x110_depth_m
         else:
             range_bearing.range_present = False
 

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ package_name = 'delivery'
 
 setup(
     name=package_name,
-    version='0.0.1',
+    version='0.0.3',
     packages=[package_name],
     data_files=[
         ('share/ament_index/resource_index/packages',


### PR DESCRIPTION
Requires [PR3](https://github.com/billmania/usbl_msgs/pull/3) from the usbl_msgs repository.

This is a breaking change for historical bag files due to a change in the RangeBearing message.

Lots of improvements to comment and doc strings, to better describe the variables and messages related to positions of the X110. The attribute mag_heading_deg in the RangeBearing messages was renamed yaw_deg, since it's actually a yaw relative to magnetic North instead of a heading.

Tested by building and launching with a fake serial port connected. No actual communication with the X150 (or pinging the X110) happened.