### PR TITLE
Add a PoseStamped message to the delivery node

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 ## Install
 
 This node requires manual installation of the OS package crcmod.
+It requires the PyPi module transforms3d.
 
 Get dependencies:
 ~~~

--- a/package.xml
+++ b/package.xml
@@ -21,6 +21,7 @@
   <depend>rclpy</depend>
   <depend>std_msgs</depend>
   <depend>usbl_msgs</depend>
+  <depend>geometry_msgs</depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/package.xml
+++ b/package.xml
@@ -18,10 +18,10 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>ament_cmake_python</buildtool_depend>
 
+  <depend>geometry_msgs</depend>
   <depend>rclpy</depend>
   <depend>std_msgs</depend>
   <depend>usbl_msgs</depend>
-  <depend>geometry_msgs</depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/scripts/delivery_node.py
+++ b/scripts/delivery_node.py
@@ -120,7 +120,10 @@ class AcommUsblNode(Node):
 
         # TODO: Use an explicit axes orientation
         #
-        # Assuming the sxyz Euler axes.
+        # Assuming the sxyz Euler axes. The pitch and yaw provided
+        # by the X150 have their signs reversed from the ROS standard,
+        # hence the multiplication by -1. The roll value is already
+        # compliant.
         #
         orientation_quaternion = euler2quat(
             radians(status_resp.roll_deg),

--- a/scripts/delivery_node.py
+++ b/scripts/delivery_node.py
@@ -11,7 +11,7 @@ import diagnostic_msgs
 import diagnostic_updater
 from geometry_msgs.msg import PoseStamped
 
-import transforms3d
+from transforms3d.euler import euler2quat
 
 from delivery.script_utils import usbl_info, usbl_setup
 from delivery.cid_callbacks import CIDCallbacks, CIDNotFound
@@ -122,7 +122,7 @@ class AcommUsblNode(Node):
         #
         # Assuming the sxyz Euler axes.
         #
-        orientation_quaternion = transforms3d.euler.euler2quat(
+        orientation_quaternion = euler2quat(
             radians(status_resp.roll_deg),
             radians(-1 * status_resp.pitch_deg),
             radians(-1 * status_resp.yaw_deg))

--- a/scripts/delivery_node.py
+++ b/scripts/delivery_node.py
@@ -124,8 +124,8 @@ class AcommUsblNode(Node):
         #
         orientation_quaternion = transforms3d.euler.euler2quat(
             radians(status_resp.roll_deg),
-            radians(status_resp.pitch_deg),
-            radians(status_resp.yaw_deg))
+            radians(-1 * status_resp.pitch_deg),
+            radians(-1 * status_resp.yaw_deg))
 
         x150_pose.pose.orientation.w = orientation_quaternion[0]
         x150_pose.pose.orientation.x = orientation_quaternion[1]

--- a/scripts/delivery_node.py
+++ b/scripts/delivery_node.py
@@ -2,11 +2,17 @@
 
 from threading import Thread
 from sys import exc_info
+from math import radians
+
 import rclpy
 from rclpy.node import Node
 from rclpy.parameter import Parameter
 import diagnostic_msgs
 import diagnostic_updater
+from geometry_msgs.msg import PoseStamped
+
+import transforms3d
+
 from delivery.script_utils import usbl_info, usbl_setup
 from delivery.cid_callbacks import CIDCallbacks, CIDNotFound
 from delivery.callback_funcs import CallbackFuncs
@@ -92,7 +98,13 @@ class AcommUsblNode(Node):
 
     def _x150_status_cb(self, status_resp: StatusResp):
         x150_status = X150Status()
+        x150_pose = PoseStamped()
+
         x150_status.header.stamp = self.get_clock().now().to_msg()
+        x150_pose.header.stamp = x150_status.header.stamp
+
+        # TODO: Be less brute force about the frame
+        x150_pose.header.frame_id = 'base_link'
 
         x150_status.timestamp_sec = status_resp.timestamp_sec
 
@@ -101,11 +113,27 @@ class AcommUsblNode(Node):
         x150_status.pressure_mb = status_resp.pressure_mb
         x150_status.depth_m = status_resp.depth_m
         x150_status.sound_mps = status_resp.sound_mps
+
         x150_status.yaw_deg = status_resp.yaw_deg
         x150_status.pitch_deg = status_resp.pitch_deg
         x150_status.roll_deg = status_resp.roll_deg
 
+        # TODO: Use an explicit axes orientation
+        #
+        # Assuming the sxyz Euler axes.
+        #
+        orientation_quaternion = transforms3d.euler.euler2quat(
+            radians(status_resp.roll_deg),
+            radians(status_resp.pitch_deg),
+            radians(status_resp.yaw_deg))
+
+        x150_pose.pose.orientation.w = orientation_quaternion[0]
+        x150_pose.pose.orientation.x = orientation_quaternion[1]
+        x150_pose.pose.orientation.y = orientation_quaternion[2]
+        x150_pose.pose.orientation.z = orientation_quaternion[3]
+
         self._x150_status_pub.publish(x150_status)
+        self._x150_pose_pub.publish(x150_pose)
 
     def _range_bearing_cb(self,
                           x110_range_m: float,
@@ -230,6 +258,8 @@ class AcommUsblNode(Node):
                                                         'range_bearing', 10)
         self._x150_status_pub = self.create_publisher(X150Status,
                                                       'x150_status', 10)
+        self._x150_pose_pub = self.create_publisher(PoseStamped,
+                                                    'x150_pose', 10)
 
     def _ping_response_diag(self):
         self._pings_response += 1


### PR DESCRIPTION
Using the orienation data from the X150 AHRS, which is already published as the X150Status message, publish a new PoseStamped message. The timestamps in the two messages will be the same.

This capability was added to facilitate displaying the X150 orientation via rviz AND comparing it to the orientation data from the PixHawk.

Tested with the ROV on the floor in the garage, comparing to the /mavros/imu/data data. We did notice that there can sometimes be a consistent discrepancy between the PixHawk yaw and the X150 yaw.